### PR TITLE
chore(ownership): add CODEOWNERS; ci(release): use npm-publish environment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owners for all files
+* @HiroXSoftwareSolutions
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: npm-publish
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
This PR adds CODEOWNERS and configures the release workflow to use an environment (npm-publish) for guarded publishing.