### PR TITLE
chore: Husky v10 pre-push + hardened release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,21 @@ jobs:
           node-version: 20.x
           cache: npm
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
-      - run: npm test
-      - run: npm pack --dry-run
-      - name: Publish to npm with provenance (OIDC)
+      - name: Install deps
+        run: npm ci
+      - name: Generate OpenAPI types (optional)
+        env:
+          FLUXOMAIL_OPENAPI: ${{ vars.FLUXOMAIL_OPENAPI }}
+        run: npm run codegen:openapi
+      - name: Run tests
+        run: npm test
+      - name: Verify package contents
+        run: npm run ci:pack-check
+      - name: Who am I (npm)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm whoami || true
+      - name: Publish to npm with provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,14 @@ on:
   push:
     tags:
       - 'v*'
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to publish (e.g., refs/tags/v0.3.0)'
+        required: false
+        default: ''
 
 jobs:
   publish:
@@ -14,6 +22,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref != '' && inputs.ref || (github.event_name == 'release' && github.event.release.tag_name || github.ref) }}
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 20.x

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 echo "[husky] Pre-push: running local checks"
 
 # Optional: OpenAPI codegen drift (runs only if FLUXOMAIL_OPENAPI is set)
@@ -18,4 +15,3 @@ npm test || exit 1
 npm run ci:pack-check || exit 1
 
 echo "[husky] Pre-push checks passed"
-


### PR DESCRIPTION
- Update pre-push hook to Husky v10 style (no husky.sh sourcing)
- Add local checks: codegen drift (optional), tests, pack contents
- Strengthen release workflow: codegen via FLUXOMAIL_OPENAPI, tests, pack-check, npm whoami, publish with provenance using NPM_TOKEN in npm-publish env