### PR TITLE
fix(codegen): stub types when FLUXOMAIL_OPENAPI missing; remove local fallback

### DIFF
--- a/scripts/generate-openapi-types.mjs
+++ b/scripts/generate-openapi-types.mjs
@@ -12,25 +12,32 @@ async function main() {
     const mod = await import('openapi-typescript')
     openapiTS = mod && (mod.default || mod)
   } catch {}
-  try {
-    const envSpec = process.env.FLUXOMAIL_OPENAPI
-    const fallbackSpec = '/Users/pierreillsley/Documents/GitHub/email-service/openapi/2025-09-01.yaml'
-    let spec = envSpec && envSpec.trim() ? envSpec.trim() : ''
-    if (!spec) {
-      // Use fallback if present locally
-      try { await stat(fallbackSpec); spec = fallbackSpec } catch {}
-    }
-    if (openapiTS && spec) {
-      const types = await openapiTS(spec, { httpHeaders: true })
+  const envSpec = (process.env.FLUXOMAIL_OPENAPI || '').trim()
+  const isHttp = (s) => s.startsWith('http://') || s.startsWith('https://')
+  const fileExists = async (p) => { try { await stat(p); return true } catch { return false } }
+
+  if (openapiTS && envSpec && (isHttp(envSpec) || await fileExists(envSpec))) {
+    try {
+      const types = await openapiTS(envSpec)
       await writeFile(outFile, String(types))
       console.log('Generated types to', outFile)
       return
+    } catch (e) {
+      console.error('OpenAPI codegen failed:', e && e.message ? e.message : String(e))
     }
-  } catch (e) {
-    console.error('OpenAPI codegen failed:', e && e.message ? e.message : String(e))
+  } else if (envSpec) {
+    console.warn('FLUXOMAIL_OPENAPI is set but not a valid file/URL; writing stub types')
+  } else {
+    console.log('FLUXOMAIL_OPENAPI not provided; writing stub types')
   }
-  await writeFile(outFile, "// Placeholder types\nexport type Placeholder = unknown;\n")
-  console.log('Wrote placeholder types to', outFile)
+
+  const stub = `// Auto-generated stub (no OpenAPI spec available)\n` +
+`export type HttpMethod = 'get'|'put'|'post'|'delete'|'patch'|'options'|'head'|'trace';\n` +
+`export type paths = Record<string, Partial<Record<HttpMethod, any>>>;\n` +
+`export type components = { schemas?: Record<string, any> } & Record<string, any>;\n`
+
+  await writeFile(outFile, stub)
+  console.log('Wrote stub types to', outFile)
 }
 
 main().catch(() => {})


### PR DESCRIPTION
This makes codegen resilient to missing secrets on forks and to openapi-typescript v7 behavior.\n\n- Pre-validate spec as file/URL before invoking openapi-typescript\n- Write minimal stub for PRs from forks (no secrets)\n- Compatible with openapi-typescript v6 and v7\n\nCI: Should keep main codegen+drift check gated, while PRs compile/tests run with stub types.