### PR TITLE
fix(pkg): align repository/bugs URLs with repo for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,11 +50,11 @@
   "author": "Fluxomail",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/fluxomail/fluxomail-sdk-js.git"
+    "url": "https://github.com/HiroXSoftwareSolutions/fluxomail-sdk-js"
   },
   "homepage": "https://docs.fluxomail.com/api-reference/fluxomail/cli",
   "bugs": {
-    "url": "https://github.com/fluxomail/fluxomail-sdk-js/issues"
+    "url": "https://github.com/HiroXSoftwareSolutions/fluxomail-sdk-js/issues"
   },
   "license": "Apache-2.0",
   "publishConfig": {


### PR DESCRIPTION
NPM provenance validation failed during publish:\n\n> Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "git+https://github.com/fluxomail/fluxomail-sdk-js.git", expected to match "https://github.com/HiroXSoftwareSolutions/fluxomail-sdk-js" from provenance\n\nThis updates package.json:\n- repository.url → https://github.com/HiroXSoftwareSolutions/fluxomail-sdk-js\n- bugs.url → https://github.com/HiroXSoftwareSolutions/fluxomail-sdk-js/issues\n\nAfter merge, Release Please will open 0.3.2; merging that will publish successfully with provenance.