### PR TITLE
chore(ci): add release-as input to Release Please and use PAT fallback

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      release_as:
+        description: 'Override version (e.g., 0.3.3)'
+        required: false
+        default: ''
 
 jobs:
   release-please:
@@ -13,3 +18,5 @@ jobs:
       - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4
         with:
           config-file: .release-please-config.json
+          release-as: ${{ inputs.release_as }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN != '' && secrets.RELEASE_PLEASE_TOKEN || github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,21 @@ jobs:
           node-version: 20.x
           cache: npm
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
-      - run: npm test
-      - run: npm pack --dry-run
-      - name: Publish to npm with provenance (OIDC)
+      - name: Install deps
+        run: npm ci
+      - name: Generate OpenAPI types (optional)
+        env:
+          FLUXOMAIL_OPENAPI: ${{ vars.FLUXOMAIL_OPENAPI }}
+        run: npm run codegen:openapi
+      - name: Run tests
+        run: npm test
+      - name: Verify package contents
+        run: npm run ci:pack-check
+      - name: Who am I (npm)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm whoami || true
+      - name: Publish to npm with provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -33,7 +37,23 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm whoami || true
+      - name: Compute version
+        id: ver
+        run: echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+      - name: Check if version already on npm
+        id: exists
+        run: |
+          set -euo pipefail
+          V="${{ steps.ver.outputs.version }}"
+          echo "Checking npm for version $V"
+          if npm view @fluxomail/sdk versions --json | jq -e ". | index(\"$V\")" >/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Version $V already published; skipping publish"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Publish to npm with provenance
+        if: steps.exists.outputs.exists == 'false'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance --access public

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 echo "[husky] Pre-push: running local checks"
 
 # Optional: OpenAPI codegen drift (runs only if FLUXOMAIL_OPENAPI is set)
@@ -18,4 +15,3 @@ npm test || exit 1
 npm run ci:pack-check || exit 1
 
 echo "[husky] Pre-push checks passed"
-


### PR DESCRIPTION
- Allow manual release bumps via workflow_dispatch input release_as\n- Use RELEASE_PLEASE_TOKEN when available to open PRs