### PR TITLE
fix(security): audit fixes for 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 This project uses SemVer. During 0.x, breaking changes may occur in minor versions.
 
+## 0.5.1 - 2026-02-19
+- security: CLI ignores `tokenCmd` from CWD-discovered `.fluxomailrc` (prevents
+  untrusted repos from executing arbitrary shell commands via planted config)
+- fix: only set `Content-Type: application/json` on requests with a body,
+  avoiding unnecessary CORS preflights on GET requests in browsers
+- fix: `init worker` now uses an inlined template instead of reading a file
+  not included in the published package
+- fix: CONTRIBUTING.md clone URL now points to correct GitHub org
+
 ## 0.5.0 - 2026-02-19
 - **Breaking**: remove Templates API (no backend implementation)
 - feat: `sends.sendGlobal()` — send via the org-level global endpoint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thanks for helping improve the Fluxomail SDK!
 
 ### Setup
 ```bash
-git clone https://github.com/fluxomail/fluxomail-sdk-js.git
+git clone https://github.com/HiroXSoftwareSolutions/fluxomail-sdk-js.git
 cd fluxomail-sdk-js
 npm install
 npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fluxomail/sdk",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fluxomail/sdk",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "eventsource": "4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluxomail/sdk",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Fluxomail SDK for JS/TS: send emails, list/subscribe to events, manage preferences, get timelines.",
   "type": "module",
   "main": "dist/index.js",

--- a/tests/cli-init.test.mjs
+++ b/tests/cli-init.test.mjs
@@ -39,7 +39,7 @@ test('CLI init worker writes example file and creates dirs', async () => {
     const file = path.join(dir, 'worker.js')
     assert.equal(await exists(file), true)
     const text = await readFile(file, 'utf8')
-    assert.ok(text.includes('Fluxomail API'))
+    assert.ok(text.includes('@fluxomail/sdk'))
   } finally { await rm(dir, { recursive: true, force: true }) }
 })
 


### PR DESCRIPTION
## Summary
- **Security**: CLI ignores `tokenCmd` from CWD-discovered `.fluxomailrc` — prevents untrusted repos from executing arbitrary shell commands via planted config files
- **Fix**: Only set `Content-Type: application/json` on requests with a body, avoiding unnecessary CORS preflights on GET requests in browsers
- **Fix**: `init worker` now uses an inlined template instead of reading a file not included in the published package
- **Fix**: CONTRIBUTING.md clone URL points to correct GitHub org

## Test plan
- [x] 47/47 tests pass (including updated cli-init worker test)
- [x] Build passes clean
- [x] `npm pack --dry-run` shows correct contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)